### PR TITLE
Support php 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
 
     services:
       mysql:

--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -2,4 +2,4 @@ name = 'PdfFileNamer'
 description = 'Personaliza los nombres de archivos PDF por tipo de documento'
 version = 1
 min_version = 2025
-min_php = 8.2
+min_php = 8.1


### PR DESCRIPTION
This pull request makes compatibility improvements by lowering the minimum required PHP version from 8.2 to 8.1 and updating the CI workflow to test against PHP 8.1 as well. These changes ensure the project can be used and tested with PHP 8.1 and newer versions.

Compatibility updates:

* Lowered the minimum required PHP version for the project to 8.1 in `facturascripts.ini`.
* Updated the CI workflow in `.github/workflows/ci.yml` to include PHP 8.1 in the test matrix.