### PR TITLE
ci: add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     services:
       mysql:


### PR DESCRIPTION
Add PHP 8.5 to the CI test matrix, alongside 8.1-8.4. Verified passing in facturascripts-plugin-AiScan (the test (8.5) leg is green on upstream FacturaScripts).